### PR TITLE
7.2 compatibility

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -2,4 +2,5 @@
 
 | Module version | Terraform version | Controller version | Terraform provider version |
 | :------------- | :---------------- | :----------------- | :------------------------- |
+| v1.1.0         | >= 1.5.0          | >= 7.2             | ~>3.2.0                    |
 | v1.0.0         | >= 1.5.0          | >= 7.1             | ~>3.1.0                    |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ module "avx_hybrid_cloud" {
   password            = var.controller_password
   my_ip               = "${chomp(data.http.myip.response_body)}/32"
   vgw_or_tgw          = "vgw"
-  edge_image_filename = "${path.module}/avx-gateway-avx-g3-202405121500.qcow2"
+  enable_hpe          = true
+  edge_image_filename = "${path.module}/avx-gateway-avx-g3-202409102334.qcow2"
 }
 
 output "gatus_dashboard_urls" {
@@ -73,20 +74,21 @@ See [example terraform](examples). You may need to modify the csp providers to m
 
 ### Optional
 
-| Key                 |                                                                                       Default value | Description                                     |
-| :------------------ | --------------------------------------------------------------------------------------------------: | :---------------------------------------------- |
-| aws_region          |                                                                                           us-east-1 | Aws region - must match provider region         |
-| azure_region        |                                                                                          Central US | Azure region                                    |
-| gcp_region          |                                                                                            us-west2 | Gcp region - must match provider region         |
-| instance_sizes      | aws = "t3.micro"<br>gcp = "n1-standard-1"<br>azure = "Standard_B1ms"<br>edge = "n1-standard-2"</br> | Instance sizes for each cloud provider          |
-| gatus_private_ips   |                                   aws = "10.1.2.40"<br>edge = "10.40.251.29"<br>azure = "10.2.2.40" | Private ips for the gatus instances             |
-| edge_instance_name  |                                                                                       edge-instance | Name of the edge gatus instance                 |
-| aws_instance_name   |                                                                                        aws-instance | Name of the aws gatus instance                  |
-| azure_instance_name |                                                                                      azure-instance | Name of the azure gatus instance                |
-| gatus_interval      |                                                                                                   5 | Interval for gatus polling (in seconds)         |
-| inbound_tcp         |                                                                                  80 = ["0.0.0.0/0"] | Inbound tcp ports for gatus instances           |
-| quagga_asn          |                                                                                               65516 | Quagga asn                                      |
-| vgw_or_tgw          |                                                                                                 vgw | Aws connectivity via aws transit or vpn gateway |
+| Key                 |                                                                                       Default value | Description                                                          |
+| :------------------ | --------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------- |
+| aws_region          |                                                                                           us-east-1 | Aws region - must match provider region                              |
+| azure_region        |                                                                                          Central US | Azure region                                                         |
+| gcp_region          |                                                                                            us-west2 | Gcp region - must match provider region                              |
+| instance_sizes      | aws = "t3.micro"<br>gcp = "n1-standard-1"<br>azure = "Standard_B1ms"<br>edge = "n1-standard-2"</br> | Instance sizes for each cloud provider                               |
+| gatus_private_ips   |                                   aws = "10.1.2.40"<br>edge = "10.40.251.29"<br>azure = "10.2.2.40" | Private ips for the gatus instances                                  |
+| edge_instance_name  |                                                                                       edge-instance | Name of the edge gatus instance                                      |
+| enable_hpe          |                                                                                                true | High performance encryption for edge attachments and transit peering |
+| aws_instance_name   |                                                                                        aws-instance | Name of the aws gatus instance                                       |
+| azure_instance_name |                                                                                      azure-instance | Name of the azure gatus instance                                     |
+| gatus_interval      |                                                                                                   5 | Interval for gatus polling (in seconds)                              |
+| inbound_tcp         |                                                                                  80 = ["0.0.0.0/0"] | Inbound tcp ports for gatus instances                                |
+| quagga_asn          |                                                                                               65516 | Quagga asn                                                           |
+| vgw_or_tgw          |                                                                                                 vgw | Aws connectivity via aws transit or vpn gateway                      |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following depicts the topology deployed.
 
 | Module version | Terraform version | Controller version | Terraform provider version |
 | :------------- | :---------------- | :----------------- | :------------------------- |
-| v1.0.0         | >= 1.5.0          | >= 7.1             | ~>3.1.0                    |
+| v1.1.0         | >= 1.5.0          | >= 7.2             | ~>3.2.0                    |
 
 ## Usage Example
 
@@ -35,7 +35,7 @@ data "http" "myip" {
 
 module "avx_hybrid_cloud" {
   source              = "terraform-aviatrix-modules/secure-hybrid-cloud/aviatrix"
-  version             = "1.0.0"
+  version             = "1.1.0"
   avx_aws_account     = var.avx_aws_account
   avx_azure_account   = var.avx_azure_account
   password            = var.controller_password
@@ -122,6 +122,7 @@ The following CSP accounts are required.
 | :----------------- | :------------- | :------------------------------------ |
 | v7.1.x             | u18            | avx-edge-kvm-7.1-2023-04-24.qcow2     |
 | v7.1.x             | u22            | avx-gateway-avx-g3-202405121500.qcow2 |
+| v7.2.x             | u22            | avx-gateway-avx-g3-202409102334.qcow2 |
 
 ### Terraform
 

--- a/azure.tf
+++ b/azure.tf
@@ -19,7 +19,7 @@ resource "azurerm_route_table" "spoke_azure_private" {
 
 module "spoke_azure" {
   source              = "Azure/vnet/azurerm"
-  version             = "4.1.0"
+  version             = "5.0.1"
   vnet_name           = "spoke-azure"
   resource_group_name = azurerm_resource_group.spoke_azure.name
   vnet_location       = azurerm_resource_group.spoke_azure.location
@@ -240,13 +240,12 @@ resource "azurerm_linux_virtual_machine" "nva" {
   admin_password        = var.password
   computer_name         = "nva"
   size                  = "Standard_B1ls"
-  # custom_data                     = data.cloudinit_config.nva.rendered
   custom_data = base64encode(templatefile("${path.module}/templates/quagga.tpl",
     {
       asn_quagga      = var.quagga_asn
       bgp_routerId    = azurerm_network_interface.nva.ip_configuration[0].private_ip_address
-      bgp_network1    = module.spoke_azure.vnet_address_space[0]
-      bgp_network2    = azurerm_virtual_network.ars.address_space[0]
+      bgp_network1    = tolist(module.spoke_azure.vnet_address_space)[0]
+      bgp_network2    = tolist(azurerm_virtual_network.ars.address_space)[0]
       routeserver_IP1 = tolist(azurerm_route_server.default.virtual_router_ips)[0]
       routeserver_IP2 = tolist(azurerm_route_server.default.virtual_router_ips)[1]
   }))

--- a/edge.tf
+++ b/edge.tf
@@ -1,11 +1,12 @@
 module "edge" {
   source              = "terraform-aviatrix-modules/gcp-edge-demo/aviatrix"
-  version             = "3.2.0"
+  version             = "3.2.1"
   region              = var.gcp_region
   pov_prefix          = "aviatrix"
   host_vm_size        = var.instance_sizes["edge"]
   test_vm_size        = var.instance_sizes["gcp"]
   host_vm_cidr        = "10.40.251.16/28"
+  enable_hpe_spoke    = var.enable_hpe
   host_vm_asn         = 64900
   host_vm_count       = 1
   edge_vm_asn         = 64581

--- a/examples/tgw/README.md
+++ b/examples/tgw/README.md
@@ -9,13 +9,14 @@ data "http" "myip" {
 
 module "avx_hybrid_cloud" {
   source              = "terraform-aviatrix-modules/secure-hybrid-cloud/aviatrix"
-  version             = "1.0.0"
+  version             = "1.1.0"
   avx_aws_account     = var.avx_aws_account
   avx_azure_account   = var.avx_azure_account
   password            = var.controller_password
   my_ip               = "${chomp(data.http.myip.response_body)}/32"
   vgw_or_tgw          = "tgw"
-  edge_image_filename = "${path.module}/avx-gateway-avx-g3-202405121500.qcow2"
+  enable_hpe          = true
+  edge_image_filename = "${path.module}/avx-gateway-avx-g3-202409102334.qcow2"
 }
 
 output "gatus_dashboard_urls" {

--- a/examples/tgw/main.tf
+++ b/examples/tgw/main.tf
@@ -10,5 +10,6 @@ module "avx_hybrid_cloud" {
   password            = var.controller_password
   my_ip               = "${chomp(data.http.myip.response_body)}/32"
   vgw_or_tgw          = "tgw"
-  edge_image_filename = "${path.module}/avx-gateway-avx-g3-202405121500.qcow2"
+  enable_hpe          = true
+  edge_image_filename = "${path.module}/avx-gateway-avx-g3-202409102334.qcow2"
 }

--- a/examples/tgw/main.tf
+++ b/examples/tgw/main.tf
@@ -4,7 +4,7 @@ data "http" "myip" {
 
 module "avx_hybrid_cloud" {
   source              = "terraform-aviatrix-modules/secure-hybrid-cloud/aviatrix"
-  version             = "1.0.0"
+  version             = "1.1.0"
   avx_aws_account     = var.avx_aws_account
   avx_azure_account   = var.avx_azure_account
   password            = var.controller_password

--- a/examples/tgw/providers.tf
+++ b/examples/tgw/providers.tf
@@ -10,7 +10,7 @@ provider "aws" {
 
 provider "azurerm" {
   features {}
-  skip_provider_registration = true
+  resource_provider_registrations = "none"
 }
 
 provider "google" {

--- a/examples/tgw/versions.tf
+++ b/examples/tgw/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     aviatrix = {
       source  = "aviatrixsystems/aviatrix"
-      version = "~> 3.1.0"
+      version = "~> 3.2.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3"
+      version = "~> 4.14.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/vgw/README.md
+++ b/examples/vgw/README.md
@@ -15,7 +15,8 @@ module "avx_hybrid_cloud" {
   password            = var.controller_password
   my_ip               = "${chomp(data.http.myip.response_body)}/32"
   vgw_or_tgw          = "vgw"
-  edge_image_filename = "${path.module}/avx-gateway-avx-g3-202405121500.qcow2"
+  enable_hpe          = true
+  edge_image_filename = "${path.module}/avx-gateway-avx-g3-202409102334.qcow2"
 }
 
 output "gatus_dashboard_urls" {

--- a/examples/vgw/README.md
+++ b/examples/vgw/README.md
@@ -9,7 +9,7 @@ data "http" "myip" {
 
 module "avx_hybrid_cloud" {
   source              = "terraform-aviatrix-modules/secure-hybrid-cloud/aviatrix"
-  version             = "1.0.0"
+  version             = "1.1.0"
   avx_aws_account     = var.avx_aws_account
   avx_azure_account   = var.avx_azure_account
   password            = var.controller_password

--- a/examples/vgw/main.tf
+++ b/examples/vgw/main.tf
@@ -10,5 +10,6 @@ module "avx_hybrid_cloud" {
   password            = var.controller_password
   my_ip               = "${chomp(data.http.myip.response_body)}/32"
   vgw_or_tgw          = "vgw"
-  edge_image_filename = "${path.module}/avx-gateway-avx-g3-202405121500.qcow2"
+  enable_hpe          = true
+  edge_image_filename = "${path.module}/avx-gateway-avx-g3-202409102334.qcow2"
 }

--- a/examples/vgw/main.tf
+++ b/examples/vgw/main.tf
@@ -4,7 +4,7 @@ data "http" "myip" {
 
 module "avx_hybrid_cloud" {
   source              = "terraform-aviatrix-modules/secure-hybrid-cloud/aviatrix"
-  version             = "1.0.0"
+  version             = "1.1.0"
   avx_aws_account     = var.avx_aws_account
   avx_azure_account   = var.avx_azure_account
   password            = var.controller_password

--- a/examples/vgw/providers.tf
+++ b/examples/vgw/providers.tf
@@ -10,7 +10,7 @@ provider "aws" {
 
 provider "azurerm" {
   features {}
-  skip_provider_registration = true
+  resource_provider_registrations = "none"
 }
 
 provider "google" {

--- a/examples/vgw/versions.tf
+++ b/examples/vgw/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     aviatrix = {
       source  = "aviatrixsystems/aviatrix"
-      version = "~> 3.1.0"
+      version = "~> 3.2.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3"
+      version = "~> 4.14.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/locals.tf
+++ b/locals.tf
@@ -8,6 +8,7 @@ locals {
       transit_region_name = var.aws_region
       transit_asn         = 65101
       transit_ha_gw       = true
+      transit_insane_mode = true
     },
     azure = {
       transit_name                        = "transit-azure"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,17 @@
 module "backbone" {
   source          = "terraform-aviatrix-modules/backbone/aviatrix"
-  version         = "v1.2.2"
+  version         = "v1.3.1"
   transit_firenet = local.backbone
+  peering_mode    = "custom"
+  peering_map = {
+    peering1 : {
+      gw1_name                                    = module.backbone.transit["aws"].transit_gateway.gw_name,
+      gw2_name                                    = module.backbone.transit["azure"].transit_gateway.gw_name,
+      enable_insane_mode_encryption_over_internet = var.enable_hpe
+      enable_max_performance                      = var.enable_hpe
+      gateway1_excluded_network_cidrs             = ["0.0.0.0/0"],
+      gateway2_excluded_network_cidrs             = ["0.0.0.0/0"],
+      tunnel_count                                = var.enable_hpe ? 2 : null
+    }
+  }
 }

--- a/tgw/main.tf
+++ b/tgw/main.tf
@@ -81,9 +81,17 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "this_2" {
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.this.id
 }
 
+data "aws_route_table" "this_transit" {
+  filter {
+    name   = "tag:Name"
+    values = ["aviatrix-transit-aws"]
+  }
+  depends_on = [aws_ec2_transit_gateway_connect_peer.this]
+}
+
 resource "aws_route" "this" {
-  count                  = 2
-  route_table_id         = var.transit_vpc.route_tables[count.index]
+  # count                  = 3
+  route_table_id         = data.aws_route_table.this_transit.id
   destination_cidr_block = "192.168.101.0/24"
   transit_gateway_id     = aws_ec2_transit_gateway.this.id
 }

--- a/tgw/versions.tf
+++ b/tgw/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aviatrix = {
       source  = "aviatrixsystems/aviatrix"
-      version = ">= 3.1.0"
+      version = ">= 3.2.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/variables.tf
+++ b/variables.tf
@@ -116,3 +116,8 @@ variable "vgw_or_tgw" {
     error_message = "Invalid AWS gateway option. Choose vgw or tgw."
   }
 }
+
+variable "enable_hpe" {
+  description = "Enable high performance encryption on the edge to transit attachment"
+  default     = true
+}

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     aviatrix = {
       source  = "aviatrixsystems/aviatrix"
-      version = ">= 3.1.0"
+      version = ">= 3.2.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3"
+      version = ">= 4.14"
     }
     google = {
       source  = "hashicorp/google"

--- a/vgw/versions.tf
+++ b/vgw/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aviatrix = {
       source  = "aviatrixsystems/aviatrix"
-      version = ">= 3.1.0"
+      version = ">= 3.2.0"
     }
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
- Adds 7.2 compatibility - avx provider `3.2.0`
- Sets hpe as default for edge attachments to transit and transit peering
- Upgrade to azurerm  - provider `4.14.0`